### PR TITLE
Update task description to include SSIS

### DIFF
--- a/task/task.json
+++ b/task/task.json
@@ -2,7 +2,7 @@
   "id": "2ac2b060-978b-11e7-84a3-f5c70df70787",
   "name": "DeployIsPacs",
   "friendlyName": "Deploy ISPACs",
-  "description": "Deploy your ISPACs to SQL Server",
+  "description": "Deploy your ISPACs to SQL SSIS Server",
   "author": "Mario Majcica",
   "groups": [
     {


### PR DESCRIPTION
For usability reasons it's helpful to include SSIS in the task description so that it appears in the task search list when searching for 'ssis', newcomers to devops would see the extension listed but no tasks from the extension.